### PR TITLE
~/mcis?option=status 호출에서 ~/mics 호출로 변경된 API 반영

### DIFF
--- a/src/static/assets/js/dashboard.manage.js
+++ b/src/static/assets/js/dashboard.manage.js
@@ -474,7 +474,7 @@ function show_vmList(mcis_id,map){
 
    
    var url = CommonURL+"/ns/"+NAMESPACE+"/mcis/"+mcis_id;
-   var mcis_url = CommonURL+"/ns/"+NAMESPACE+"/mcis?option=status";
+   var mcis_url = CommonURL+"/ns/"+NAMESPACE+"/mcis";
    var apiInfo = ApiInfo;
    console.log("vmList",url)
    if(mcis_id){

--- a/src/views/Dashboard_Ns.html
+++ b/src/views/Dashboard_Ns.html
@@ -181,7 +181,7 @@
                 if(!NAMESPACE){
                     nsid = $("#namespace1").val()
                 }
-                var url = CommonURL+"/ns/"+nsid+"/mcis?option=status";
+                var url = CommonURL+"/ns/"+nsid+"/mcis";
                 console.log("Dashboard url :",url);
                const osmLayer = new ol.layer.Tile({
                    source: new ol.source.OSM(),

--- a/src/views/MCIS_List.html
+++ b/src/views/MCIS_List.html
@@ -89,7 +89,7 @@
 								<script>
 									/* scroll */
 									$(document).ready(function(){
-										var url = CommonURL+"/ns/"+NAMESPACE+"/mcis?option=status";
+										var url = CommonURL+"/ns/"+NAMESPACE+"/mcis";
 										
 								
 											show_mcis_list2(url);

--- a/src/views/MCISlist.html
+++ b/src/views/MCISlist.html
@@ -235,7 +235,7 @@
      $(document).ready(function(){
         checkNS();
          var nsid = "{{ .NameSpace}}";
-         var url = CommonURL+"/ns/"+nsid+"/mcis?option=status";
+         var url = CommonURL+"/ns/"+nsid+"/mcis";
          console.log("url :",url);
          show_mcis(url);
      })

--- a/src/views/Monitoring.html
+++ b/src/views/Monitoring.html
@@ -252,7 +252,7 @@
      <script>
      $(document).ready(function(){
          var nsid = "{{ .NameSpace}}";
-         var url = CommonURL+"/ns/"+nsid+"/mcis?option=status";
+         var url = CommonURL+"/ns/"+nsid+"/mcis";
          console.log("url :",url);
          show_mcis(url);
      })

--- a/src/views/Monitoring_Mcis.html
+++ b/src/views/Monitoring_Mcis.html
@@ -467,7 +467,7 @@
 
 	})
 function getMcisList(nsid){
-	var url = "{{ .comURL.TumbleBugURL}}"+"/ns/"+nsid+"/mcis?option=status";
+	var url = "{{ .comURL.TumbleBugURL}}"+"/ns/"+nsid+"/mcis";
 	var apiInfo = "{{ .apiInfo}}";
 	axios.get(url,{
         headers:{

--- a/src/views/dashboard.html
+++ b/src/views/dashboard.html
@@ -433,7 +433,7 @@
                 if(!NAMESPACE){
                     nsid = $("#namespace1").val()
                 }
-                var url = CommonURL+"/ns/"+nsid+"/mcis?option=status";
+                var url = CommonURL+"/ns/"+nsid+"/mcis";
                 console.log("Dashboard url :",url);
                 const osmLayer = new ol.layer.Tile({
                     source: new ol.source.OSM(),

--- a/src/webmoa/operation/Dashboard_Ns.html
+++ b/src/webmoa/operation/Dashboard_Ns.html
@@ -345,7 +345,7 @@
                 if(!NAMESPACE){
                     nsid = $("#namespace1").val()
                 }
-                var url = CommonURL+"/ns/"+nsid+"/mcis?option=status";
+                var url = CommonURL+"/ns/"+nsid+"/mcis";
                 console.log("Dashboard url :",url);
                 const osmLayer = new ol.layer.Tile({
                     source: new ol.source.OSM(),


### PR DESCRIPTION
v0.2.9에서 status 정보가 메인 정보에 포함되며 status에서는 축소된 동적 정보로 바뀜에 따라 호출 방식 변경 됨.
