### PR TITLE
Add Issue-template and prow workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report (버그 리포트)
+about: Create a report to fix a bug
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
+
+**What happened**
+: 
+
+**What you expected to happen**
+: 
+
+**How to reproduce it (as minimally and precisely as possible)**
+: 
+
+**Anything else we need to know?**
+: 
+
+**Environment**
+- Source version or branch: 
+- OS: 
+- Others: 
+
+**Proposed solution**
+: 
+
+**Any other context**
+:

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,19 @@
+---
+name: Enhancement Request (개선 요청)
+about: Suggest an enhancement for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
+
+**What would you like to be enhanced**
+: 
+
+**Why is this needed**
+: 
+
+**Proposed solution**
+:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request (기능 및 특징 추가 요청)
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+<!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
+
+**What would you like to be added**
+: 
+
+**Why is this needed**
+:

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,10 @@
+---
+name: General Question (기타 질문)
+about: Ask a general question
+title: ''
+labels: question
+assignees: ''
+
+---
+
+<!-- Thanks for filing an issue! You can tell anything related with this project. -->

--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -1,0 +1,46 @@
+# Action by command-style comments (inspired by Kubernetes Prow)
+name: "action by command-style comments"
+
+# Event on a comment (in issue and PR)
+on:
+  issue_comment:
+    types: [ created, edited ]
+  pull_request_review_comment:
+    types: [ created, edited ]
+
+jobs:
+  execute:
+    # Execute when author_association of the comment is OWNER or MEMBER
+    if: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' }}
+    runs-on: ubuntu-18.04
+    # Execute action according to commands
+    steps:
+      # Check author_association
+      - name: Check author_association
+        run: |
+          echo event.comment.user.login is ${{ github.event.comment.user.login }}
+          echo event.comment.author_association is ${{ github.event.comment.author_association }}
+          echo Hello, this workflow is allowed to OWNER, MEMBER, COLLABORATOR.     
+
+      # Action according to command (by jpmcb/prow-github-actions)  
+      - name: Action according to command
+        if: ${{ startsWith(github.event.comment.body, '/') }}
+        uses: jpmcb/prow-github-actions@v1.1.2
+        with:
+          prow-commands: '/assign 
+            /unassign
+            /approve 
+            /retitle 
+            /area 
+            /kind 
+            /priority 
+            /remove 
+            /lgtm 
+            /close 
+            /reopen 
+            /lock 
+            /milestone 
+            /hold 
+            /cc 
+            /uncc'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR proposes 

- GitHub Issue templates
- GitHub workflow for action by command-style comments (inspired by Kubernetes Prow))

Supported comments are as follows,
/assign
/unassign
/approve
/retitle
/area
/kind
/priority
/remove
/lgtm
/close
/reopen
/lock
/milestone
/hold
/cc
/uncc

This GitHub workflow is based on jpmcb/prow-github-actions .
https://github.com/jpmcb/prow-github-actions/blob/main/docs/commands.md

You can see a demo PR from https://github.com/seokho-son/docs/pull/18 to check actions.
