### PR TITLE
Tidy markdown documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# v.0.5.0-Affogato (2021.12.16)
+# v0.5.0 (Affogato, 2021.12.16.)
 ### API Change
-- 성능개선 : MCIS/MCKS Manage에 go routin 적용
-- cb-spider v0.4.19, cb-tumblebug v0.4.16, cb-mcks v0.4.6, cb-dragonfly v0.4.4 버전의 변경된 API 반영
+- 성능개선 : MCIS/MCKS Manage에 Go routine 적용
+- CB-Spider v0.4.19, CB-Tumblebug v0.4.16, CB-MCKS v0.4.6, CB-Dragonfly v0.4.4 버전의 변경된 API 반영
 
 ### Feature
 - 작업내역 표시 추가
@@ -14,15 +14,15 @@
 
 
 
-# v0.4.0-CafeMocha (2021.06.30)
+# v0.4.0 (Cafe Mocha, 2021.06.30.)
 ### API Change
-- 모니터링 Ploicy, Threshold 추가
-- UI에서 직접 Framework 직접호출 방식 -> go server를 통해 호출하는 방식으로 변경
+- 모니터링 Policy, Threshold 추가
+- UI에서 직접 Framework 직접호출 방식 -> Go server를 통해 호출하는 방식으로 변경
 
 ### Feature
 - MCIS, VM 생성 시 Import/Export 기능 추가
 - VM 생성 시 Expert 기능 추가
-- cb-tumblebug & cb-spider & cb-dragonfly & cb-ladybug 변경된 API 반영
+- CB-Tumblebug & CB-Spider & CB-Dragonfly & cb-ladybug 변경된 API 반영
 - credential에 provider별 설정기능 보완
 - table 검색, 정렬기능 추가
 - Main화면 추가
@@ -34,7 +34,7 @@
 
 # v0.3.0-espresso (2020.12.10.)
 ### API Change
-- cb-tumblebug v0.2.9 / cb-dragonfly v0.2.8 버전의 변경된 API 반영
+- CB-Tumblebug v0.2.9 / CB-Dragonfly v0.2.8 버전의 변경된 API 반영
   - 호환성 테스트 완료 (각 프레임워크의 v0.3.0-espresso 버전과 동일)
 ### Feature
 - 신규 디자인 반영및 구조 변경
@@ -60,7 +60,7 @@
 - Dashboard 변경및 메인 내용 영문화 적용
 - 환경 & 리소스 설정 기능 변경 및 보완
 - 환경 변수에 로그인 계정 설정 추가
-- cb-tumblebug & cb-spider & cb-dragonfly 변경된 API 반영
+- CB-Tumblebug & CB-Spider & CB-Dragonfly 변경된 API 반영
 
 ### Bug Fix
 - 환경 & 리소스 설정 버그 수정

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ```
 [NOTE]
-cb-webtool is currently under development. (the latest version is 0.5 affogato)
+cb-webtool is currently under development. (The latest version is v0.5.0 (Affogato))
 So, we do not recommend using the current release in production.
 Please note that the functionalities of cb-webtool are not stable and secure yet.
 If you have any difficulties in using cb-webtool, please let us know.
@@ -28,10 +28,10 @@ cb-webtool은 1.16 이상의 Go 버전이 설치된 다양한 환경에서 실�
 <br>
 
 ## [의존성]
-cb-webtool은 내부적으로 cb-tumblebug & cb-spider & cb-dragonfly의 개방형 API를 이용하기 때문에 각 서버의 연동이 필요합니다.<br>
-- [https://github.com/cloud-barista/cb-tumblebug](https://github.com/cloud-barista/cb-tumblebug) README 참고하여 설치 및 실행 (검증된 버전 : cb-tumblebug v0.4.18)
-- [https://github.com/cloud-barista/cb-spider](https://github.com/cloud-barista/cb-spider) README 참고하여 설치 및 실행 (검증된 버전 : cb-spider v0.4.19)
-- [https://github.com/cloud-barista/cb-dragonfly](https://github.com/cloud-barista/cb-dragonfly) README 참고하여 설치 및 실행 (검증된 버전 : cb-dragonfly v0.2.8)
+cb-webtool은 내부적으로 CB-Tumblebug & CB-Spider & CB-Dragonfly의 개방형 API를 이용하기 때문에 각 서버의 연동이 필요합니다.<br>
+- [https://github.com/cloud-barista/cb-tumblebug](https://github.com/cloud-barista/cb-tumblebug) README 참고하여 설치 및 실행 (검증된 버전 : CB-Tumblebug v0.4.18)
+- [https://github.com/cloud-barista/cb-spider](https://github.com/cloud-barista/cb-spider) README 참고하여 설치 및 실행 (검증된 버전 : CB-Spider v0.4.19)
+- [https://github.com/cloud-barista/cb-dragonfly](https://github.com/cloud-barista/cb-dragonfly) README 참고하여 설치 및 실행 (검증된 버전 : CB-Dragonfly v0.2.8)
 - [https://github.com/cloud-barista/cb-mcks](https://github.com/cloud-barista/cb-mcks) README 참고하여 설치 및 실행 (검증된 버전 : cb-mcks v0.4.6)
 
 <br>
@@ -68,17 +68,17 @@ cb-webtool은 내부적으로 cb-tumblebug & cb-spider & cb-dragonfly의 개방�
 <br>
 
 ## [환경 설정]
-   - conf/setup.env 파일에서 cb-tumblebug & cb-spider & cb-dragonfly의 실제 URL 정보로 수정합니다.<br><br>
+   - conf/setup.env 파일에서 CB-Tumblebug & CB-Spider & CB-Dragonfly의 실제 URL 정보로 수정합니다.<br><br>
      **[주의사항]**<br> cb-webtool을 비롯하여 연동되는 모든 서버가 자신의 로컬 환경에서 개발되는 경우를 제외하고는 클라이언트의 웹브라우저에서 접근하기 때문에 localhost나 127.0.0.1 주소가 아닌 실제 IP 주소를 사용해야 합니다.
 
    - 로그인 Id와 Password의 변경은 conf/setup.env 파일의 LoginEmail & LoginPassword 정보를 수정하세요.<br>
      (기본 값은 admin/admin 입니다.)
 
    - 초기 Data 구축관련<br>
-     내부적으로 [cb-spider](https://github.com/cloud-barista/cb-spider)와 [cb-tumblebug](https://github.com/cloud-barista/cb-tumblebug)의 개방형 API를 사용하므로 입력되는 Key Name및 Key Value는 cb-spider 및 cb-tumblebug의 API 문서를 참고하시기 바랍니다.<br>
+     내부적으로 [CB-Spider](https://github.com/cloud-barista/cb-spider)와 [CB-Tumblebug](https://github.com/cloud-barista/cb-tumblebug)의 개방형 API를 사용하므로 입력되는 Key Name및 Key Value는 CB-Spider 및 CB-Tumblebug의 API 문서를 참고하시기 바랍니다.<br>
 
      **[중요]**<br>
-     Cloud Connection 기능을 사용할 수 없으므로 cb-tumblebug의 [활용 예시](https://github.com/cloud-barista/cb-spider#%ED%99%9C%EC%9A%A9-%EC%98%88%EC%8B%9C_)를 참고해서 **[1.configureSpider](https://github.com/cloud-barista/cb-tumblebug#1-%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C%EC%A0%95%EB%B3%B4-namespace-mcir-mcis-%EB%93%B1-%EA%B0%9C%EB%B3%84-%EC%A0%9C%EC%96%B4-%EC%8B%9C%ED%97%98) 쉘 스크립트를 실행** 하시기 바랍니다.
+     Cloud Connection 기능을 사용할 수 없으므로 CB-Tumblebug의 [활용 예시](https://github.com/cloud-barista/cb-spider#%ED%99%9C%EC%9A%A9-%EC%98%88%EC%8B%9C_)를 참고해서 **[1.configureSpider](https://github.com/cloud-barista/cb-tumblebug#1-%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C%EC%A0%95%EB%B3%B4-namespace-mcir-mcis-%EB%93%B1-%EA%B0%9C%EB%B3%84-%EC%A0%9C%EC%96%B4-%EC%8B%9C%ED%97%98) 쉘 스크립트를 실행** 하시기 바랍니다.
 
 <br>
 


### PR DESCRIPTION
`v0.3.0` 의 태그명은 `v0.3.0-espresso` 가 맞는데,
`v0.4.0` 부터는 태그명도 `v0.4.0` 라서
이를 Changelog에 반영하였으며
그 외에도 마크다운을 약간 업데이트 하였습니다. 😊